### PR TITLE
add vector library to pool.cpp

### DIFF
--- a/threadpool11/src/pool.cpp
+++ b/threadpool11/src/pool.cpp
@@ -23,6 +23,7 @@ This file is part of threadpool11.
 #include <boost/lockfree/queue.hpp>
 
 #include <algorithm>
+#include <vector>
 
 namespace threadpool11 {
 


### PR DESCRIPTION
The build fails while compiling pool.cpp in threadpool11 and complaining ` pool.cpp:68:10: error: ‘vector’ is not a member of ‘std’.` Including `<vector>` fixes the problem. 